### PR TITLE
Error on aerospike-client-ruby 2.0.0 

### DIFF
--- a/fluent-plugin-aerospike-cluster.gemspec
+++ b/fluent-plugin-aerospike-cluster.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "fluentd"
-  spec.add_runtime_dependency "aerospike", '>= 1.0.0'
+  spec.add_runtime_dependency "aerospike", '>= 1.0.0', '< 2.0.0'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,5 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'fluent/test'
 require 'fluent/plugin/out_aerospike_cluster'
 
+Test::Unit.run = true if defined?(Test::Unit) && Test::Unit.respond_to?(:run=)
+


### PR DESCRIPTION
> Aerospike::Client.new_many
>  has been removed as the regular new method can now accept multiple hostnames.

https://github.com/aerospike/aerospike-client-ruby/blob/v2.0.0/docs/api-changes.md#client-initializer
